### PR TITLE
feat: initial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# fastify-plugin-example
+# Redirect Away From Heroku
 
-Fastify plugin template.
+Fastify plugin to redirect away from a Heroku domain.
 
 ## Github Actions/Workflows
 

--- a/index.js
+++ b/index.js
@@ -2,8 +2,16 @@
 
 const fp = require('fastify-plugin')
 
-async function fastifyPluginTemplate (fastify, options) {
+async function redirectOnRequest (fastify, opts) {
+  const { authHost, herokuAppName } = opts
+  await fastify.addHook('onRequest', redirect)
 
+  async function redirect (req, reply) {
+    const { hostname, url } = req
+    if (hostname.startsWith(herokuAppName)) {
+      await reply.redirect(301, `${authHost}${url}`)
+    }
+  }
 }
 
-module.exports = fp(fastifyPluginTemplate, { name: 'fastify-plugin-template' })
+module.exports = fp(redirectOnRequest, { name: 'redirect-on-request' })

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fastify-plugin-template",
+  "name": "@autotelic/redirect-away-from-heroku",
   "version": "0.0.0",
   "description": "Plugin for fastify",
   "main": "index.js",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,50 @@
+const { test } = require('tap')
+const Fastify = require('fastify')
+
+const redirect = require('.')
+
+test('if host name starts with heroku app name, redirect to custom domain', async ({ equal, end }) => {
+  const reqHost = 'http://example-api.herokuapp.com'
+  const reqPath = '/foo'
+  const authHost = 'http://example.com'
+
+  const fastify = Fastify()
+
+  fastify.register(redirect, {
+    authHost: authHost,
+    herokuAppName: 'example-api'
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: `${reqHost}${reqPath}`
+  })
+
+  equal(response.headers.location, `${authHost}${reqPath}`, 'response should redirect to custom domain')
+
+  equal(response.statusCode, 301)
+
+  end()
+})
+
+test('if host name does NOT start with heroku app name, do NOT redirect to custom domain', async ({ not, end }) => {
+  const reqHost = 'http://example.com'
+  const reqPath = '/foo'
+  const authHost = 'http://example.com'
+
+  const fastify = Fastify()
+
+  fastify.register(redirect, {
+    authHost: authHost,
+    herokuAppName: 'example-api'
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: `${reqHost}${reqPath}`
+  })
+
+  not(response.statusCode, 301)
+
+  end()
+})


### PR DESCRIPTION
### Summary
> A small plugin extracted from Harpocrates to handle redirection from Heroku
(@autotelic/devs reference: https://github.com/autotelic/harpocrates/tree/main/plugins/redirect-away-from-heroku-domain)

### Test Plan
- `npm test`